### PR TITLE
Add test to management and default interface

### DIFF
--- a/spec/configuration/interfaces_spec.rb
+++ b/spec/configuration/interfaces_spec.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'yaml'
 
 describe 'Default Route Interface' do
-  management_interface = command("awk '/management_interface:/ { print $2 }' /etc/redborder/rb_init_conf.yml").stdout.strip
+  cmd = "awk '/management_interface:/ { print $2 }' /etc/redborder/rb_init_conf.yml"
+  management_interface = command(cmd).stdout.strip
 
   describe command('ip route show default') do
-    its(:stdout) { should match /default via .* dev #{management_interface}\s/ }
+    its(:stdout) { should match(/default via .* dev #{management_interface}\s/) }
   end
 end

--- a/spec/configuration/interfaces_spec.rb
+++ b/spec/configuration/interfaces_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'yaml'
+
+describe 'Default Route Interface' do
+  management_interface = command("awk '/management_interface:/ { print $2 }' /etc/redborder/rb_init_conf.yml").stdout.strip
+
+  describe command('ip route show default') do
+    its(:stdout) { should match /default via .* dev #{management_interface}\s/ }
+  end
+end


### PR DESCRIPTION
Adds a test in `interfaces_spec.rb` to ensure the default route matches the management interface defined in `rb_init_conf.yml`. Enhances network config validation.
